### PR TITLE
Restrict timeline height when in single artist view

### DIFF
--- a/MakeMusicDay/event-schedule/css/styles.css
+++ b/MakeMusicDay/event-schedule/css/styles.css
@@ -356,6 +356,17 @@ derived from this CSS on this page: https://popper.js.org/tooltip-examples.html
     margin-right: 0;
 }
 
+
+@media screen and (min-width:700px) {
+  .single-artist-schedule .fc-resource-area.fc-widget-content .fc-scroller, .single-artist-schedule .fc-time-area.fc-widget-content .fc-scroller {
+    height: 450px !important;
+  }
+
+  .single-artist-schedule .timeZoneDiv {
+    margin: 0 !important;
+  }
+}
+
 /* meta styles */
 
 #cities {


### PR DESCRIPTION
Hey @chrisgundersen this was pretty basic but once this PR and the [mobile style PR](https://github.com/chrisgundersen/chrisgundersen.github.io/pull/2) are both merged and situated I'll probably need to roll through and make sure the single artist view is catching the mobile styles correctly.

Thanks!