### PR TITLE
Adjustments to Long Text

### DIFF
--- a/MakeMusicDay/event-schedule/artists.html
+++ b/MakeMusicDay/event-schedule/artists.html
@@ -270,7 +270,7 @@ var timeZoneGuess = moment.tz.guess();
                     }
 
                     mobileScheduleViewContainer.appendChild(mobileArtistDiv);
-                });    
+                });
     }
 
     document.addEventListener('DOMContentLoaded', function () {
@@ -287,7 +287,7 @@ var timeZoneGuess = moment.tz.guess();
         var currentYear = new Date().getFullYear();
         var firstEvent;
 
-        
+
 
         if (params.has('artistId')) {
             toggleSortDiv.hidden = true;
@@ -330,7 +330,7 @@ var timeZoneGuess = moment.tz.guess();
             // cityNameEl.innerHTML = selectedCity.name;
             // contactUsEl.setAttribute('href', selectedCity.contact_us_url);
 
-            
+
 
             var timeZoneGuessOption = document.createElement('option');
             timeZoneGuessOption.text = 'Your local timezone (best guess: "' + timeZoneGuess + '")';
@@ -373,7 +373,6 @@ var timeZoneGuess = moment.tz.guess();
                         events.push({
                             start: e.utc_start_time,
                             end: e.utc_end_time,
-                            // title: e.venue.name,
                             title: e.artist.name + ' @ ' + e.venue.name,
                             artist: e.artist,
                             resourceId: e.artist.id,
@@ -476,7 +475,7 @@ var timeZoneGuess = moment.tz.guess();
                     }
                 })
 
-                
+
                 loadMobileView(resources, events, selectedCity, timeZoneGuess);
 
 
@@ -586,7 +585,7 @@ var timeZoneGuess = moment.tz.guess();
                             var start = moment(info.event.start);
                             var end = moment(info.event.end);
 
-                            if (end.diff(start, 'minutes') <= 60) {
+                            if (end.diff(start, 'minutes') <= 50) {
                                 titleEl.classList.add('short-event');
                             }
 
@@ -992,7 +991,7 @@ var timeZoneGuess = moment.tz.guess();
                         //         tmpRes.push(resource);
                         //     }
 
-                            
+
                         // });
 
                         // return tmpRes;
@@ -1003,7 +1002,7 @@ var timeZoneGuess = moment.tz.guess();
                     var res = getResourcesFilteredByGenre();
                     var timezone = $("#time-zone-selector").val();
                     loadMobileView(res, events, selectedCity, timezone);
-                    // if (genreSelectorEl.value === '_all') 
+                    // if (genreSelectorEl.value === '_all')
                     //     calendar.setOption('resources', resources);
                     // } else {
                     //     filteredResources = [];

--- a/MakeMusicDay/event-schedule/css/styles.css
+++ b/MakeMusicDay/event-schedule/css/styles.css
@@ -372,7 +372,7 @@ derived from this CSS on this page: https://popper.js.org/tooltip-examples.html
 }
 
 .tooltip {
-  max-width: 370px;
+  left: 75px !important;
 }
 
 .style5 .tooltip {

--- a/MakeMusicDay/event-schedule/css/styles.css
+++ b/MakeMusicDay/event-schedule/css/styles.css
@@ -32,6 +32,15 @@ body {
     height: 120px;
 }
 
+.short-event {
+  color: rgba(0,0,0,0.8);
+  position: absolute !important;
+  padding-top: 1em;
+  left: 110% !important;
+  min-width: 290px !important;
+  max-width: 500px !important;
+}
+
 .navigationUrl {
     color: #FFFFFF;
 }
@@ -76,8 +85,9 @@ body {
 
 .fc-timeline-event .fc-title {
   display: block;
-  font-size: 1.4em;
+  font-size: 1.2em;
   font-weight: bold;
+  max-width: 500px;
 }
 
 .fc-timeline-event .fc-title span {
@@ -373,6 +383,8 @@ derived from this CSS on this page: https://popper.js.org/tooltip-examples.html
 
 .tooltip {
   left: 75px !important;
+  max-height: 420px;
+  overflow: scroll;
 }
 
 .style5 .tooltip {


### PR DESCRIPTION
Hey @chrisgundersen two different tweaks here. One is just making the "Read More" pop up box a little wider and the other is trying to deal with the overflowing event titles.

I ended up not being a fan of the "Add Read More to Events" idea but I think what I've got going now is a decent solution. Basically on events less than 50 minutes long the event title and button will just reposition to be to the right of the orange bar.

Something weird though is that the `short-event` class is not being applied to every event it needs to be. I'm not sure what's going sideways but if you scroll through the timeline you'll see there are several that definitely under the time limit but aren't getting the class. 

If there's a fix for that I think we might be good. Thanks!